### PR TITLE
RabbitMQ: base URL getting from Redux state.

### DIFF
--- a/packages/network/middlewares/rabbitmq/RmqManager.js
+++ b/packages/network/middlewares/rabbitmq/RmqManager.js
@@ -3,7 +3,6 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-import SockJS from 'sockjs-client'
 import webstomp from 'webstomp-client'
 
 class RmqManager {
@@ -18,7 +17,7 @@ class RmqManager {
     this.client && this.ws && this.disconnect()
     return new Promise((resolve, reject) => {
       try {
-        this.ws = new SockJS(baseUrl)
+        this.ws = new WebSocket(baseUrl)
       } catch (error) {
         return reject(error.message)
       }

--- a/packages/network/middlewares/rabbitmq/RmqManager.js
+++ b/packages/network/middlewares/rabbitmq/RmqManager.js
@@ -25,6 +25,7 @@ class RmqManager {
       this.client = webstomp.over(this.ws, {
         heartbeat: false,
         debug: false,
+        binary: true,
       })
 
       this.client.connect(

--- a/packages/network/middlewares/rabbitmq/constants.js
+++ b/packages/network/middlewares/rabbitmq/constants.js
@@ -5,7 +5,6 @@
 
 export const DUCK_RMQ_MIDDLEWARE = 'rmq_middleware'
 
-export const BASE_URL = 'https://rabbitmq-webstomp.chronobank.io/stomp'
 export const USER = 'rabbitmq_user'
 export const PASSWORD = '38309100024'
 

--- a/packages/network/middlewares/rabbitmq/index.js
+++ b/packages/network/middlewares/rabbitmq/index.js
@@ -4,9 +4,9 @@
  */
 
 import RmqManager from './RmqManager'
-// import { getRmqSubscriptions } from './selectors'
+import { getCurrentNetworkRmqbaseUrl } from '../../redux/selectors'
+
 import {
-  BASE_URL,
   MW_RMQ_CONNECT,
   MW_RMQ_DISCONNECT,
   MW_RMQ_SUBSCRIBE,
@@ -59,7 +59,14 @@ const createRmqMiddleware = () => {
       onStompError,
       onWebSocketClose,
     }
-    return RmqManager.connect(BASE_URL, USER, PASSWORD, handlers)
+
+    const state = store.getState()
+    const rabbitMqBaseUrl = getCurrentNetworkRmqbaseUrl(state)
+    if (!rabbitMqBaseUrl) {
+      return Promise.reject('You must select a network by NETWORK_SELECT action before connecting to RabbitMQ')
+    }
+
+    return RmqManager.connect(rabbitMqBaseUrl, USER, PASSWORD, handlers)
       .then(() => {
         next(Actions.rmqConnectSuccess())
         return Promise.resolve()

--- a/packages/network/redux/initialState.js
+++ b/packages/network/redux/initialState.js
@@ -45,6 +45,18 @@ const availableChronoBankMiddlewareNodes = {
 }
 
 /**
+ * This is a list of all available RabbitMQ nodes
+ */
+const availableRabbitMqNodes = {
+  [MAINNET]: {
+    BASE_URL: 'wss://rabbitmq-prod-ws.chronobank.io/ws',
+  },
+  [TESTNET]: {
+    BASE_URL: 'wss://rabbitmq-stage-webstomp.chronobank.io/ws',
+  },
+}
+
+/**
  * This is a list of all available Ethereum nodes
  */
 const INFURA_TOKEN = 'PVe9zSjxTKIP3eAuAHFA'
@@ -275,6 +287,7 @@ export default {
       networkTitle: 'ChronoBank - Mainnet (production)',
       networkType: MAINNET,
       primaryNode: availableEthereumNodes[MAINNET].chronobank,
+      rabbitMqBaseUrl: availableRabbitMqNodes[MAINNET].BASE_URL,
     },
     {
       blockchain: blockchainMainnet,
@@ -284,6 +297,7 @@ export default {
       networkTitle: 'Infura - Mainnet (production)',
       networkType: MAINNET,
       primaryNode: availableEthereumNodes[MAINNET].infura,
+      rabbitMqBaseUrl: availableRabbitMqNodes[MAINNET].BASE_URL,
     },
     {
       blockchain: blockchainTestnet,
@@ -293,6 +307,7 @@ export default {
       networkTitle: 'ChronoBank - Rinkeby (testnet)',
       networkType: TESTNET,
       primaryNode: availableEthereumNodes[TESTNET].chronobank,
+      rabbitMqBaseUrl: availableRabbitMqNodes[TESTNET].BASE_URL,
     },
     {
       blockchain: blockchainTestnet,
@@ -302,6 +317,7 @@ export default {
       networkTitle: 'Infura - Rinkeby (testnet)',
       networkType: TESTNET,
       primaryNode: availableEthereumNodes[TESTNET].infura,
+      rabbitMqBaseUrl: availableRabbitMqNodes[TESTNET].BASE_URL,
     },
     // {
     //   blockchain: blockchainTestnet,

--- a/packages/network/redux/selectors.js
+++ b/packages/network/redux/selectors.js
@@ -31,6 +31,11 @@ export const getCurrentNetworkBlockchains = createSelector(
   (selected) => selected.blockchain
 )
 
+export const getCurrentNetworkRmqbaseUrl = createSelector(
+  getCurrentNetwork,
+  (selected) => selected.rabbitMqBaseUrl
+)
+
 export const getCurrentNetworkBlockchainChannels = (blockchain) => createSelector(
   getCurrentNetworkBlockchains,
   (blockchains) => blockchains[blockchain].channels


### PR DESCRIPTION
connect thunks of RMQ get it directly from Redux store
During reconnect by NETWORK_SELECT it should obtain new URL automatically (to be implemented and tested in other tasks)